### PR TITLE
Add `win32` platform support.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,17 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+        - name: Windows
+          os: windows-latest
+          mill: 'mill --no-server'
+        - name: Linux
+          os: ubuntu-latest
+          mill: 'mill'
+    name: ${{ matrix.name }}
+    runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v1
     - uses: ./
@@ -15,5 +25,5 @@ jobs:
       with:
         mill-version: 0.8.0
     - name: "Run Mill"
-      run: mill version
+      run: ${{ matrix.mill }} version
 

--- a/setup.js
+++ b/setup.js
@@ -19,8 +19,9 @@ async function run() {
       core.info('downloading mill');
       const downloadPath = await tc.downloadTool(`https://github.com/lihaoyi/mill/releases/download/${millVersion}/${millVersion}-assembly`);
       await io.mkdirP(millPath);
-      await io.cp(downloadPath, `${millPath}/mill`, { force: true });
-      fs.chmodSync(`${millPath}/mill`, '0755')
+      const targetPath = process.platform === 'win32' ? `${millPath}/mill.bat` : `${millPath}/mill`;
+      await io.cp(downloadPath, targetPath, { force: true });
+      fs.chmodSync(targetPath, '0755') // This shouldn't do anything on win32
       cachedMillPath = await tc.cacheDir(millPath, 'mill', millVersion);
     } else {
       core.info(`using cached version of mill: ${cachedMillPath}`);
@@ -31,7 +32,8 @@ async function run() {
     // TODO: once caching across workflow invocations is available, this dorectory should be cached too
     //       (note that caching would only help for multiple jobs, as data is cached in the home directory
     //       which is shared across steps)
-    await exec.exec('mill', ['version']);
+    const millOptions = process.platform === 'win32' ? [ '--no-server' ] : [];
+    await exec.exec('mill', millOptions.concat(['version']));
   }
   catch (error) {
     core.setFailed(error.message);


### PR DESCRIPTION
This adds Windows support to the mill action, using the `--no-server`
option since it fails on the Github CI with a similar error message
to https://github.com/lihaoyi/mill/issues/675.