### PR TITLE
Version bumps

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Use this action to make [mill](http://www.lihaoyi.com/mill/) available in a job.
 ```yaml
 - uses: jodersky/setup-mill@master
   with:
-    mill-version: 0.8.0
+    mill-version: 0.10.4
 - name: Compile
   run: mill project.compile
 # the server process is kept alive across steps,

--- a/package.json
+++ b/package.json
@@ -6,6 +6,6 @@
     "@actions/core": "^1.2.6",
     "@actions/exec": "^1.0.4",
     "@actions/io": "^1.0.2",
-    "@actions/tool-cache": "^1.6.1"
+    "@actions/tool-cache": "^2.0.1"
   }
 }


### PR DESCRIPTION
- action's tool-cache has [major version bump ](https://www.npmjs.com/package/@actions/tool-cache). The [changes](https://github.com/actions/toolkit/blob/main/packages/tool-cache/RELEASES.md) aren't huge (mostly another dep update), but there will be more minor/patch versions we might want to pick up
- run ci action with latest mill